### PR TITLE
docs: clarify mission creation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ This project handles mission management and reporting aspects of drone operation
 ### Mission Creation
 `POST /missions` accepts the following fields:
 - `orgId`, `name`, `area` (GeoJSON Polygon), `altitude`, `pattern`, `overlap`
-
 - `dataFrequency` &ndash; optional data collection frequency in hertz (defaults to `1`)
-
-- `dataFrequency` &ndash; data collection frequency in hertz
-
 - `sensors` &ndash; optional array of sensor identifiers to activate during the mission
 
 At FlytBase, we prioritize high-quality, reliable features over superficial coverage. Focus on thoughtful design and engineering to deliver well-crafted solutions.


### PR DESCRIPTION
## Summary
- refine Mission Creation API documentation

## Testing
- `npm test`
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ad38b938832cb35910f18fbfe741