### PR TITLE
Display mission outcomes in analytics dashboard

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -149,7 +149,9 @@ function createMissionsRouter(io) {
           start_time: new Date(mission.startTime).toISOString(),
           end_time: new Date(mission.endTime).toISOString(),
           data_frequency: mission.dataFrequency,
-          sensors: mission.sensors
+          sensors: mission.sensors,
+          status: mission.status,
+          failure_reason: mission.failureReason
         };
         reports.set(mission.id, report);
       }

--- a/Backend/src/routes/reports.js
+++ b/Backend/src/routes/reports.js
@@ -31,6 +31,8 @@ router.get('/missions/:id', (req, res) => {
           : 0;
       const summary = {
         mission_id: report.mission_id,
+        status: mission ? mission.status : report.status || null,
+        failure_reason: mission ? mission.failureReason : report.failure_reason || null,
         duration: report.duration,
         distance,
         // If the mission has been purged fall back to the coverage value stored in
@@ -50,6 +52,8 @@ router.get('/missions/:id', (req, res) => {
     const sensorList = mission.sensors || [];
     const summary = {
       mission_id: mission.id,
+      status: mission.status,
+      failure_reason: mission.failureReason,
       duration:
         mission.startTime && mission.endTime
           ? (mission.endTime - mission.startTime) / 1000

--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -17,6 +17,16 @@ function AnalyticsDashboard() {
   const [missionError, setMissionError] = useState(null);
   const defaultOutcomes = { success: 0, batteryFailure: 0, damageFailure: 0 };
 
+  const formatOutcome = (status, failureReason) => {
+    if (status === 'failed') {
+      if (failureReason === 'battery') return 'Battery Failure';
+      if (failureReason === 'damage') return 'Damage Failure';
+      return 'Failure';
+    }
+    if (status === 'completed') return 'Success';
+    return status || 'N/A';
+  };
+
   const fetchJson = (url) =>
     fetch(`${API_BASE_URL}${url}`).then(async (res) => {
       const contentType = res.headers.get('content-type') || '';
@@ -110,6 +120,12 @@ function AnalyticsDashboard() {
         )}
         {missionSummary && (
           <ul>
+            <li>
+              Outcome: {formatOutcome(
+                missionSummary.status,
+                missionSummary.failure_reason
+              )}
+            </li>
             <li>Duration: {missionSummary.duration}s</li>
             <li>Distance: {missionSummary.distance.toFixed(2)}m</li>
             <li>Waypoints: {missionSummary.waypoints}</li>


### PR DESCRIPTION
## Summary
- include status and failure_reason when generating mission reports
- expose mission outcomes in per-mission report API response
- show mission outcome in Analytics dashboard per-mission summary

## Testing
- `npm test` (backend)
- `npm install` (frontend) *(fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)*
- `npm test -- --watchAll=false` (frontend) *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b2431fec832ca0e995e3363a9b7b