### PR TITLE
Allow square survey areas

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -41,12 +41,16 @@ function createMissionsRouter(io) {
     if (!orgId || !name || !area || !altitude || !pattern) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
+    const areaType = (area.type || '').toLowerCase();
     if (
-      area.type !== 'Polygon' ||
+      (areaType !== 'polygon' && areaType !== 'square') ||
       (!Array.isArray(area.coordinates) && typeof area.coordinates !== 'object')
     ) {
-      return res.status(400).json({ error: 'Area must be a GeoJSON Polygon' });
+      return res
+        .status(400)
+        .json({ error: 'Area must be a GeoJSON Polygon or Square' });
     }
+    area.type = areaType.charAt(0).toUpperCase() + areaType.slice(1);
 
     if (
       dataFrequency !== undefined &&

--- a/Backend/src/server.js
+++ b/Backend/src/server.js
@@ -14,6 +14,12 @@ const io = socketIo(server);
 // Middleware setup
 app.use(cors());
 app.use(express.json());
+app.use((err, _req, res, next) => {
+  if (err instanceof SyntaxError && 'body' in err) {
+    return res.status(400).json({ error: 'Invalid JSON' });
+  }
+  next();
+});
 
 // Routes
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project handles mission management and reporting aspects of drone operation
 ## API Notes
 ### Mission Creation
 `POST /missions` accepts the following fields:
-- `orgId`, `name`, `area` (GeoJSON Polygon), `altitude`, `pattern`, `overlap`
+- `orgId`, `name`, `area` (GeoJSON Polygon or Square), `altitude`, `pattern`, `overlap`
 - `dataFrequency` &ndash; optional data collection frequency in hertz (defaults to `1`)
 - `sensors` &ndash; optional array of sensor identifiers to activate during the mission
 


### PR DESCRIPTION
## Summary
- allow mission creation with 'Square' or 'Polygon' area types via normalized check and clearer error message
- return JSON error for malformed request bodies instead of HTML
- document that missions may specify a GeoJSON Polygon or Square

## Testing
- `cd Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72e985d74832c9bb302d5588c1480