### PR TITLE
fix: normalize square coordinates

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -16,11 +16,15 @@ function createMissionsRouter(io) {
   function normalizeCoords(input) {
     if (!input) return [];
     if (Array.isArray(input)) {
-      return Array.isArray(input[0]) ? input[0] : input;
+      return Array.isArray(input[0]) && Array.isArray(input[0][0])
+        ? input[0]
+        : input;
     }
     if (typeof input === 'object') {
       const values = Object.values(input);
-      return Array.isArray(values[0]) ? values[0] : values;
+      return Array.isArray(values[0]) && Array.isArray(values[0][0])
+        ? values[0]
+        : values;
     }
     return [];
   }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project handles mission management and reporting aspects of drone operation
 ### Mission Creation
 `POST /missions` accepts the following fields:
 - `orgId`, `name`, `area` (GeoJSON Polygon or Square), `altitude`, `pattern`, `overlap`
+- The `area.coordinates` field may be provided either as a GeoJSON ring (`[[[lng,lat],...]]`) or as a flat array of `[lng,lat]` pairs
 - `dataFrequency` &ndash; optional data collection frequency in hertz (defaults to `1`)
 - `sensors` &ndash; optional array of sensor identifiers to activate during the mission
 


### PR DESCRIPTION
## Summary
- ensure mission coordinate normalization handles nested and flat arrays
- document accepted coordinate formats for mission creation

## Testing
- `npm test`
- `curl -X POST http://localhost:5001/missions -H "Content-Type: application/json" -d '{"orgId":"demo","name":"Nested","area":{"type":"Square","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]},"altitude":10,"pattern":"perimeter"}'`
- `curl -X POST http://localhost:5001/missions -H "Content-Type: application/json" -d '{"orgId":"demo","name":"Flat","area":{"type":"Square","coordinates":[[0,0],[0,1],[1,1],[1,0],[0,0]]},"altitude":10,"pattern":"perimeter"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b731534908832caa8f615fade43f0f