### PR TITLE
fix: normalize square coordinates

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -16,11 +16,15 @@ function createMissionsRouter(io) {
   function normalizeCoords(input) {
     if (!input) return [];
     if (Array.isArray(input)) {
-      return Array.isArray(input[0]) ? input[0] : input;
+      return Array.isArray(input[0]) && Array.isArray(input[0][0])
+        ? input[0]
+        : input;
     }
     if (typeof input === 'object') {
       const values = Object.values(input);
-      return Array.isArray(values[0]) ? values[0] : values;
+      return Array.isArray(values[0]) && Array.isArray(values[0][0])
+        ? values[0]
+        : values;
     }
     return [];
   }
@@ -42,10 +46,13 @@ function createMissionsRouter(io) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
     const areaType = (area.type || '').toLowerCase();
-    if (
-      (areaType !== 'polygon' && areaType !== 'square') ||
-      (!Array.isArray(area.coordinates) && typeof area.coordinates !== 'object')
-    ) {
+    const rawCoords = normalizeCoords(area.coordinates);
+    if (areaType !== 'polygon' && areaType !== 'square') {
+      return res
+        .status(400)
+        .json({ error: 'Area must specify type Polygon or Square' });
+    }
+    if (!rawCoords.length) {
       return res
         .status(400)
         .json({ error: 'Area must be a GeoJSON Polygon or Square' });
@@ -68,7 +75,6 @@ function createMissionsRouter(io) {
     // Support GeoJSON-style coordinate arrays as well as simple arrays or
     // objects of {lat,lng} points that may come from the frontend. Any shape
     // we cannot interpret is treated as an error instead of crashing.
-    const rawCoords = normalizeCoords(area.coordinates);
     const waypoints = generateWaypoints(rawCoords, altitude, pattern, overlap);
     if (!waypoints.length) {
       return res

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project handles mission management and reporting aspects of drone operation
 ### Mission Creation
 `POST /missions` accepts the following fields:
 - `orgId`, `name`, `area` (GeoJSON Polygon or Square), `altitude`, `pattern`, `overlap`
+- The `area.coordinates` field may be provided either as a GeoJSON ring (`[[[lng,lat],...]]`) or as a flat array of `[lng,lat]` pairs. The backend will close the polygon automatically if the final point is omitted.
 - `dataFrequency` &ndash; optional data collection frequency in hertz (defaults to `1`)
 - `sensors` &ndash; optional array of sensor identifiers to activate during the mission
 


### PR DESCRIPTION
## Summary
- validate and normalize mission area coordinates before waypoint generation
- clarify coordinate formats and automatic polygon closing in the README

## Testing
- `npm test`
- `curl -s -X POST http://localhost:5001/missions -H "Content-Type: application/json" -d '{"orgId":"demo","name":"Nested","area":{"type":"Square","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]},"altitude":10,"pattern":"perimeter"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b731534908832caa8f615fade43f0f