### PR TITLE
feat: add header to analytics frontend

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -28,6 +28,12 @@
   color: #61dafb;
 }
 
+.App-nav {
+  background-color: #282c34;
+  color: white;
+  padding: 1rem;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,9 @@ import AnalyticsDashboard from './AnalyticsDashboard';
 function App() {
   return (
     <div className="App">
+      <header className="App-nav">
+        <h1>FlytBase Analytics</h1>
+      </header>
       <AnalyticsDashboard />
     </div>
   );


### PR DESCRIPTION
## Summary
- add top navigation header for FlytBase Analytics
- style header with dark theme

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7387615fc832c9b92411b6d8ab0d2